### PR TITLE
Fixes #1082  修复在更新token无操作有效期时的时间判断问题

### DIFF
--- a/paas2/login/bkauth/utils.py
+++ b/paas2/login/bkauth/utils.py
@@ -115,7 +115,7 @@ def is_bk_token_valid(bk_token):  # NOQA
 
     # 更新 无操作有效期
     try:
-        if now_time > inactive_expire_time + settings.BK_INACTIVE_UPDATE_INTERVEL:
+        if now_time + BK_INACTIVE_COOKIE_AGE > inactive_expire_time + settings.BK_INACTIVE_UPDATE_INTERVEL:
             BkToken.objects.filter(token=bk_token).update(inactive_expire_time=now_time + BK_INACTIVE_COOKIE_AGE)
     except Exception:
         logger.exception("update inactive_expire_time fail")

--- a/paas2/login/bkauth/utils.py
+++ b/paas2/login/bkauth/utils.py
@@ -115,6 +115,9 @@ def is_bk_token_valid(bk_token):  # NOQA
 
     # 更新 无操作有效期
     try:
+        # 为避免每个请求都刷新inactive_expire_time造成性能问题，在对inactive_expire_time续期前，进行更新时间间隔判断
+        # 表记录中的inactive_expire_time = 上一个now_time + BK_INACTIVE_COOKIE_AGE
+        # 需判断 (当前时间 + BK_INACTIVE_COOKIE_AGE) > (inactive_expire_time + 更新时间间隔)，才进行续期
         if now_time + BK_INACTIVE_COOKIE_AGE > inactive_expire_time + settings.BK_INACTIVE_UPDATE_INTERVEL:
             BkToken.objects.filter(token=bk_token).update(inactive_expire_time=now_time + BK_INACTIVE_COOKIE_AGE)
     except Exception:


### PR DESCRIPTION
<!--
请保证PR标题明确清晰, 易于理解
Keep PR title verbose enough

相关issue可以是 #编号 或者贴 issue链接
`Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


## 变更点(Changes)

- 修复在更新token无操作有效期时的时间判断问题

## 相关issues (Which issues this PR fixes)

- Fixes #1082 

## 备注(Special notes)
BkToken表中inactive_expire_time字段，在更新时，是基于当前时间+ 无操作失效期，即inactive_expire_time = now_time + BK_INACTIVE_COOKIE_AGE。
在原代码中，更新inactive_expire_time前的判断(该判断是为了避免频繁更新inactive_expire_time带来的性能问题)：
if now_time > inactive_expire_time + settings.BK_INACTIVE_UPDATE_INTERVEL:
存在问题，相当于是：if now_time > (now_time1 + BK_INACTIVE_COOKIE_AGE) + settings.BK_INACTIVE_UPDATE_INTERVEL:
判断结果基本不可能为true，不会进入到更新inactive_expire_time代码。
因此，需要修复为：
if now_time + BK_INACTIVE_COOKIE_AGE > inactive_expire_time + settings.BK_INACTIVE_UPDATE_INTERVEL
